### PR TITLE
Enable local search

### DIFF
--- a/src/components/Collections/CollectionCard.jsx
+++ b/src/components/Collections/CollectionCard.jsx
@@ -34,8 +34,22 @@ const CollectionCard = ({ collection }) => {
     }
   }, []);
 
+  let standIn;
 
-  return (
+  if (import.meta.env.VITE_LOCAL_SEARCH) {
+
+    standIn = ownerData
+
+  } else {
+
+    standIn = collection
+  }
+
+
+
+
+
+ if (collection && ownerData) { return (
     <Card sx={{ maxWidth: 345 }}>
       {/* Clicking anywhere on the card opens Collection Detail page */}
       <CardActionArea href={`/collections/${collection._id}`}>
@@ -50,7 +64,7 @@ const CollectionCard = ({ collection }) => {
           title={collection.name}
         />
         {/* If card is on home view, show collection owner's profile picture */}
-        {username === collection.createdBy.username ? (
+        {username === standIn.createdBy.username ? (
           <CardHeader
             sx={{ height: "85px" }}
             avatar={
@@ -129,7 +143,7 @@ const CollectionCard = ({ collection }) => {
         )}
       </CardActionArea>
     </Card>
-  );
+  );}
 };
 
 export default CollectionCard;


### PR DESCRIPTION
It's a bit tricky, cause for some reason one word in the Collection Card component works when we search Atlas.

So in lines 37 to 46 of the colelction card you'll now find reference to an env variable - if that one is in your .env file, the "standIn" variable will be set to "ownerData" - this enables the local search to not break.

when you want to use Atlas, you just need to comment out the env variable, and it should work 

The reason is that when connected to the local db, the search doesnt seem to find a "collection.createdBy.username" but it finds the "ownerdata.createdBy.username" which is essentially the same for some reason.

I hope it works with Atlas, only checked with local tho. If there is a problem with Atlas while you test this, you know what it was.