### PR TITLE
Create item form layout

### DIFF
--- a/src/components/DynamicSearch/SearchBar.jsx
+++ b/src/components/DynamicSearch/SearchBar.jsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useNavigate } from "react-router-dom";
 import TextField from "@mui/material/TextField";
 import Autocomplete from "@mui/material/Autocomplete";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -15,6 +16,7 @@ function sleep(delay = 0) {
 }
 
 export default function SearchBar() {
+  const navigate = useNavigate();
   const [open, setOpen] = React.useState(false);
   const [options, setOptions] = React.useState([]);
   const [selectedOption, setSelectedOption] = React.useState(null);
@@ -28,7 +30,7 @@ export default function SearchBar() {
     setSelectedOption(value);
 
     if (value.title === "Create Item") {
-      window.location.href = "/create-item";
+      navigate("/create-item", { state: { fromSearch: true } });
     } else if (value.title === "Create Collection") {
       window.location.href = "/create-collection";
     } else if (value.title === "Search...") {
@@ -87,10 +89,9 @@ export default function SearchBar() {
 
   useEffect(() => {
     axios
-      .get(`${API_URL}/users`,
-      {
-				headers: { Authorization: `Bearer ${storedToken}` },
-			})
+      .get(`${API_URL}/users`, {
+        headers: { Authorization: `Bearer ${storedToken}` },
+      })
       .then((res) => {
         setAllUserNames(res.data.map((user) => user.username));
       })
@@ -101,10 +102,9 @@ export default function SearchBar() {
 
   useEffect(() => {
     axios
-      .get(`${API_URL}/collections`,
-      {
-				headers: { Authorization: `Bearer ${storedToken}` },
-			})
+      .get(`${API_URL}/collections`, {
+        headers: { Authorization: `Bearer ${storedToken}` },
+      })
       .then((res) => {
         setAllCollectionNames(
           res.data.collections.map((collection) => collection.name)
@@ -117,10 +117,9 @@ export default function SearchBar() {
 
   useEffect(() => {
     axios
-      .get(`${API_URL}/items`,
-      {
-				headers: { Authorization: `Bearer ${storedToken}` },
-			})
+      .get(`${API_URL}/items`, {
+        headers: { Authorization: `Bearer ${storedToken}` },
+      })
       .then((res) => {
         setAllItemNames(res.data.items.map((item) => item.name));
       })

--- a/src/components/Items/CreateItemForm.jsx
+++ b/src/components/Items/CreateItemForm.jsx
@@ -32,6 +32,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
   const [aiErrorMessage, setAiErrorMessage] = useState(undefined);
   const [isLoading, setIsLoading] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isDescriptionGenerated, setIsDescriptionGenerated] = useState(false);
 
   const storedToken = localStorage.getItem("authToken");
   const navigate = useNavigate();
@@ -69,6 +70,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
       const generatedDescription = completion.data.choices[0].message.content;
       console.log(generatedDescription);
       setDescription(generatedDescription);
+      setIsDescriptionGenerated(true);
     } catch (error) {
       console.error(error);
       setAiErrorMessage(error.message);
@@ -159,6 +161,9 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
       })
       .catch((err) => {
         console.error(err);
+      })
+      .finally(() => {
+        setIsDescriptionGenerated(false);
       });
   };
 
@@ -233,9 +238,11 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
               Auto-Description
             </Button>
             <div className="py-1" key={Date.now()}>
-              {isGenerating && (
-                <MoonLoader key={Date.now()} color="#1976D2" size={22} />
-              )}
+              <MoonLoader
+                color="#1976D2"
+                size={22}
+                loading={isGenerating && !isDescriptionGenerated}
+              />
             </div>
           </div>
 

--- a/src/components/Items/CreateItemForm.jsx
+++ b/src/components/Items/CreateItemForm.jsx
@@ -11,6 +11,8 @@ import ImageUploader from "../ImageUploader/ImageUploader";
 import SelectCategories from "../SelectCategories";
 
 // MUI imports
+import { Textarea, Input } from "@mui/joy";
+
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 
@@ -182,8 +184,9 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
             <Typography variant="button">Item Name</Typography>{" "}
             <Typography variant="caption">(required)</Typography>
           </label>
-          <input
+          <Input
             type="text"
+            size="lg"
             id="name"
             className={fixedInputClass}
             value={name}
@@ -212,7 +215,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
             <Typography variant="button">Item Description</Typography>
           </label>
 
-          <textarea
+          <Textarea
             id="description"
             className={fixedInputClass}
             value={description}
@@ -247,7 +250,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           <label htmlFor="comment" className="text-md">
             <Typography variant="button">Your Thoughts?</Typography>
           </label>
-          <textarea
+          <Textarea
             id="comment"
             className={fixedInputClass}
             value={comment}

--- a/src/components/Items/CreateItemForm.jsx
+++ b/src/components/Items/CreateItemForm.jsx
@@ -90,7 +90,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
 
   const createDescription = async (name) => {
     setIsGenerating(true);
-    console.log("createDescription");
+    setIsDescriptionGenerated(false);
 
     try {
       await createChatCompletion(name);
@@ -232,7 +232,10 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           <div className="flex flex-row gap-2">
             <Button
               variant="outlined"
-              onClick={() => createDescription(name)}
+              onClick={() => {
+                setIsDescriptionGenerated(false);
+                createDescription(name);
+              }}
               className="text-xl mb-4"
             >
               Auto-Description

--- a/src/components/Items/CreateItemForm.jsx
+++ b/src/components/Items/CreateItemForm.jsx
@@ -166,7 +166,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
   // STYLING
   // -------------------------------------------------------
   const fixedInputClass =
-    "w-full p-2 mt-1 mb-3 border border-slate-800 placeholder-gray-300 text-slate-800";
+    "w-full rounded p-2 mt-1 mb-3 border border-slate-800 placeholder-gray-300 text-slate-800";
 
   // -------------------------------------------------------
   // RENDER
@@ -215,7 +215,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
             <Typography variant="button">Item Description</Typography>
           </label>
 
-          <Textarea
+          <textarea
             id="description"
             className={fixedInputClass}
             value={description}
@@ -232,7 +232,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
             >
               Auto-Description
             </Button>
-            <div className="py-1">
+            <div className="py-1" key={Date.now()}>
               {isGenerating && (
                 <MoonLoader key={Date.now()} color="#1976D2" size={22} />
               )}
@@ -250,7 +250,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           <label htmlFor="comment" className="text-md">
             <Typography variant="button">Your Thoughts?</Typography>
           </label>
-          <Textarea
+          <textarea
             id="comment"
             className={fixedInputClass}
             value={comment}
@@ -295,7 +295,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
             <Button variant="contained" type="submit" className="text-xl mt-3">
               Add Item
             </Button>
-            <div className="mt-3 mx-2 py-1">
+            <div className="mt-3 mx-2 py-1" key={Date.now()}>
               {isLoading && (
                 <MoonLoader key={Date.now()} color="#1976D2" size={22} />
               )}

--- a/src/components/Items/CreateItemForm.jsx
+++ b/src/components/Items/CreateItemForm.jsx
@@ -28,6 +28,8 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
   const [commentTitle, setCommentTitle] = useState("");
   const [uploadingImage, setUploadingImage] = useState(false);
   const [aiErrorMessage, setAiErrorMessage] = useState(undefined);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
 
   const storedToken = localStorage.getItem("authToken");
   const navigate = useNavigate();
@@ -83,14 +85,22 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
   };
 
   const createDescription = async (name) => {
+    setIsGenerating(true);
     console.log("createDescription");
-    await createChatCompletion(name);
-    await waitForDescription();
+
+    try {
+      await createChatCompletion(name);
+      await waitForDescription();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsGenerating(false);
+    }
   };
 
   const handleSubmit = async (event) => {
     event.preventDefault();
-
+    setIsLoading(true);
     // -------------------------------------------------------
     // IMAGE UPLOADS POWERED BY CLOUDINARY
     // -------------------------------------------------------
@@ -169,7 +179,8 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           {/* Item Name */}
           {/* ------------------------------ */}
           <label htmlFor="name" className="text-md">
-            <Typography variant="button">Item Name</Typography>
+            <Typography variant="button">Item Name</Typography>{" "}
+            <Typography variant="caption">(required)</Typography>
           </label>
           <input
             type="text"
@@ -198,7 +209,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           {/* ------------------------------ */}
 
           <label htmlFor="description" className="text-md mt-3 pt-4">
-            <Typography variant="button">Description</Typography>
+            <Typography variant="button">Item Description</Typography>
           </label>
 
           <textarea
@@ -210,7 +221,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
             placeholder="Try our automatic description generation by clicking the Auto-Description button below and wait for the magic to happen."
           />
           {/* Generate Description Button */}
-          <div>
+          <div className="flex flex-row gap-2">
             <Button
               variant="outlined"
               onClick={() => createDescription(name)}
@@ -218,6 +229,11 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
             >
               Auto-Description
             </Button>
+            <div className="py-1">
+              {isGenerating && (
+                <MoonLoader key={Date.now()} color="#1976D2" size={22} />
+              )}
+            </div>
           </div>
 
           {/* OpenAI Error Message */}
@@ -229,7 +245,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           {/* Comment */}
           {/* ------------------------------ */}
           <label htmlFor="comment" className="text-md">
-            <Typography variant="button">Comment</Typography>
+            <Typography variant="button">Your Thoughts?</Typography>
           </label>
           <textarea
             id="comment"
@@ -244,7 +260,8 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           {/* Upload Item Picture */}
           {/* ------------------------------ */}
           <label htmlFor="categories" className="text-md mt-4 pb-1">
-            <Typography variant="button">Upload Item Picture</Typography>
+            <Typography variant="button">Upload Item Picture</Typography>{" "}
+            <Typography variant="caption">(.JPEG or .PNG)</Typography>
           </label>
           {/* Upload preview */}
           <div className="pb-1">
@@ -271,15 +288,20 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           {/* ------------------------------ */}
           {/* SUBMIT ITEM */}
           {/* ------------------------------ */}
-          <div>
+          <div className="flex flex-row">
             <Button variant="contained" type="submit" className="text-xl mt-3">
-              Add item
+              Add Item
             </Button>
+            <div className="mt-3 mx-2 py-1">
+              {isLoading && (
+                <MoonLoader key={Date.now()} color="#1976D2" size={22} />
+              )}
+            </div>
           </div>
         </form>
 
         {/* Error message */}
-        <div className="my-2">
+        <div className="my-4">
           {errorMessage && <p className="text-danger">{errorMessage}</p>}
         </div>
       </div>

--- a/src/components/Items/CreateItemForm.jsx
+++ b/src/components/Items/CreateItemForm.jsx
@@ -3,6 +3,7 @@ import { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AuthContext } from "../../context/auth.context";
 import API_URL from "../../services/apiConfig";
+import { MoonLoader } from "react-spinners";
 import { Configuration, OpenAIApi } from "openai";
 
 // Custom components
@@ -168,7 +169,7 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           {/* Item Name */}
           {/* ------------------------------ */}
           <label htmlFor="name" className="text-md">
-            Item Name
+            <Typography variant="button">Item Name</Typography>
           </label>
           <input
             type="text"
@@ -183,8 +184,8 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           {/* ------------------------------ */}
           {/* Item Category Selection */}
           {/* ------------------------------ */}
-          <label htmlFor="categories" className="text-md pb-1">
-            Categories
+          <label htmlFor="categories" className="text-md mt-3 pb-1">
+            <Typography variant="button">Categories</Typography>
           </label>
 
           <SelectCategories
@@ -196,13 +197,9 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           {/* Generate Auto-Description */}
           {/* ------------------------------ */}
 
-          <label htmlFor="description" className="text-md pt-4">
-            Description
+          <label htmlFor="description" className="text-md mt-3 pt-4">
+            <Typography variant="button">Description</Typography>
           </label>
-          {/* OpenAI Error Message */}
-          <div className="mb-1">
-            {aiErrorMessage && <p className="text-danger">{aiErrorMessage}</p>}
-          </div>
 
           <textarea
             id="description"
@@ -223,11 +220,16 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
             </Button>
           </div>
 
+          {/* OpenAI Error Message */}
+          <div className="mb-3">
+            {aiErrorMessage && <p className="text-danger">{aiErrorMessage}</p>}
+          </div>
+
           {/* ------------------------------ */}
           {/* Comment */}
           {/* ------------------------------ */}
           <label htmlFor="comment" className="text-md">
-            Comment
+            <Typography variant="button">Comment</Typography>
           </label>
           <textarea
             id="comment"
@@ -242,20 +244,20 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           {/* Upload Item Picture */}
           {/* ------------------------------ */}
           <label htmlFor="categories" className="text-md mt-4 pb-1">
-            Upload Item Picture
+            <Typography variant="button">Upload Item Picture</Typography>
           </label>
           {/* Upload preview */}
-          <div className="pb-4">
+          <div className="pb-1">
             {uploadingImage === true ? (
-              <p>Uploading image, please wait...</p>
+              <MoonLoader color="#1976D2" size={30} />
             ) : (
               <img
                 src={
                   imageUrl !== "" ? imageUrl : "/images/default/no-image.svg"
                 }
-                width={250}
-                height={350}
+                width={350}
                 alt=""
+                className="rounded-lg"
               />
             )}
           </div>

--- a/src/components/Items/CreateItemForm.jsx
+++ b/src/components/Items/CreateItemForm.jsx
@@ -164,7 +164,9 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
         <form className="flex flex-col mx-auto" onSubmit={handleSubmit}>
           <input type="hidden" name="forCollection" value={forCollection} />
 
-          {/* Item title */}
+          {/* ------------------------------ */}
+          {/* Item Name */}
+          {/* ------------------------------ */}
           <label htmlFor="name" className="text-md">
             Item Name
           </label>
@@ -178,7 +180,52 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
 
           <input type="hidden" name="" value={currentUser._id} />
 
-          {/* Collecion description */}
+          {/* ------------------------------ */}
+          {/* Item Category Selection */}
+          {/* ------------------------------ */}
+          <label htmlFor="categories" className="text-md pb-1">
+            Categories
+          </label>
+
+          <SelectCategories
+            setCategoryArray={setCategoryArray}
+            categoryArray={categoryArray}
+          />
+
+          {/* ------------------------------ */}
+          {/* Generate Auto-Description */}
+          {/* ------------------------------ */}
+
+          <label htmlFor="description" className="text-md pt-4">
+            Description
+          </label>
+          {/* OpenAI Error Message */}
+          <div className="mb-1">
+            {aiErrorMessage && <p className="text-danger">{aiErrorMessage}</p>}
+          </div>
+
+          <textarea
+            id="description"
+            className={fixedInputClass}
+            value={description}
+            rows={4}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Try our automatic description generation by clicking the Auto-Description button below and wait for the magic to happen."
+          />
+          {/* Generate Description Button */}
+          <div>
+            <Button
+              variant="outlined"
+              onClick={() => createDescription(name)}
+              className="text-xl mb-4"
+            >
+              Auto-Description
+            </Button>
+          </div>
+
+          {/* ------------------------------ */}
+          {/* Comment */}
+          {/* ------------------------------ */}
           <label htmlFor="comment" className="text-md">
             Comment
           </label>
@@ -191,18 +238,14 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
             placeholder="Let the community know your thoughts about this item, e.g. why you're using it, or whether you think it's good or not. Short or long description, anything goes!"
           />
 
-          {/* item category selection */}
-          <label htmlFor="categories" className="text-md pb-1">
-            Categories
+          {/* ------------------------------ */}
+          {/* Upload Item Picture */}
+          {/* ------------------------------ */}
+          <label htmlFor="categories" className="text-md mt-4 pb-1">
+            Upload Item Picture
           </label>
-          <SelectCategories
-            setCategoryArray={setCategoryArray}
-            categoryArray={categoryArray}
-          />
-
-          {/* Upload item cover picture */}
           {/* Upload preview */}
-          <div className="py-4">
+          <div className="pb-4">
             {uploadingImage === true ? (
               <p>Uploading image, please wait...</p>
             ) : (
@@ -221,41 +264,15 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           <ImageUploader
             setImageUrl={setImageUrl}
             setUploadingImage={setUploadingImage}
-            message={"Upload a cover picture"}
           />
 
-          {/* Create description button */}
-          <label htmlFor="description" className="text-md">
-            Description
-          </label>
-          <textarea
-            id="description"
-            className={fixedInputClass}
-            value={description}
-            rows={4}
-            onChange={(event) => setDescription(event.target.value)}
-          />
-
-          <div>
-            <Button
-              variant="contained"
-              onClick={() => createDescription(name)}
-              className="text-xl mt-3"
-            >
-              Create Description
-            </Button>
-          </div>
-
-          {/* Create item button */}
+          {/* ------------------------------ */}
+          {/* SUBMIT ITEM */}
+          {/* ------------------------------ */}
           <div>
             <Button variant="contained" type="submit" className="text-xl mt-3">
               Add item
             </Button>
-          </div>
-
-          {/* AI error message */}
-          <div className="my-2">
-            {aiErrorMessage && <p className="text-danger">{aiErrorMessage}</p>}
           </div>
         </form>
 

--- a/src/components/Items/CreateItemForm.jsx
+++ b/src/components/Items/CreateItemForm.jsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { useState, useContext, useEffect } from "react";
+import { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AuthContext } from "../../context/auth.context";
 import API_URL from "../../services/apiConfig";
@@ -17,7 +17,6 @@ import Typography from "@mui/material/Typography";
 
 const CreateitemForm = ({ target, idObject, forCollection }) => {
   const { user } = useContext(AuthContext);
-
   const [currentUser, setCurrentUser] = useState(user);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -31,6 +30,10 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
 
   const storedToken = localStorage.getItem("authToken");
   const navigate = useNavigate();
+
+  // -------------------------------------------------------
+  // AUTOMATIC DESCRIPTIONS POWERED BY OPENAI API
+  // -------------------------------------------------------
 
   const createChatCompletion = async (name) => {
     try {
@@ -87,9 +90,10 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
   const handleSubmit = async (event) => {
     event.preventDefault();
 
-    //something wrong with headers
+    // -------------------------------------------------------
+    // IMAGE UPLOADS POWERED BY CLOUDINARY
+    // -------------------------------------------------------
 
-    // Uploading cover images is optional
     if (uploadingImage) {
       return;
     }
@@ -121,6 +125,10 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
       };
     }
 
+    // -------------------------------------------------------
+    // SEND DATA TO BACKEND
+    // -------------------------------------------------------
+
     axios
       .post(`${API_URL}/${target}`, params, {
         headers: { Authorization: `Bearer ${storedToken}` },
@@ -141,9 +149,15 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
       });
   };
 
+  // -------------------------------------------------------
+  // STYLING
+  // -------------------------------------------------------
   const fixedInputClass =
     "w-full p-2 mt-1 mb-3 border border-slate-800 placeholder-gray-300 text-slate-800";
 
+  // -------------------------------------------------------
+  // RENDER
+  // -------------------------------------------------------
   return (
     currentUser && (
       <div className="mb-3">

--- a/src/components/Items/CreateItemForm.jsx
+++ b/src/components/Items/CreateItemForm.jsx
@@ -257,15 +257,6 @@ const CreateitemForm = ({ target, idObject, forCollection }) => {
           <div className="my-2">
             {aiErrorMessage && <p className="text-danger">{aiErrorMessage}</p>}
           </div>
-
-          <div id="main-section" className="p-4">
-            <Typography variant="h6" sx={{ color: "red" }}>
-              Creating new items works, it just takes a long time before the
-              process is finished due to auto-generated descriptions taking a
-              while. We still need to add loading spinners, until then give it a
-              little time before you'll see the created item.
-            </Typography>
-          </div>
         </form>
 
         {/* Error message */}

--- a/src/components/Items/CreateItemSearch.jsx
+++ b/src/components/Items/CreateItemSearch.jsx
@@ -294,9 +294,14 @@ const CreateItemSearch = () => {
                 <Grid item xs={12} sm={6} md={4} lg={3} key={item._id}>
                   <ItemCard key={item._id} item={item} />
                   {/* Button triggers a modal that prompts the user to write an optional comment */}
-                  <Button onClick={() => handleOpen(item)}>
-                    Add this item
-                  </Button>
+                  <div className="my-3 text-center">
+                    <Button
+                      variant="contained"
+                      onClick={() => handleOpen(item)}
+                    >
+                      Add this item
+                    </Button>
+                  </div>
                   <Dialog
                     open={openModal}
                     onClose={handleClose}

--- a/src/components/SelectCategories.jsx
+++ b/src/components/SelectCategories.jsx
@@ -27,13 +27,13 @@ const SelectCategories = ({ categoryArray, setCategoryArray }) => {
       .get(`${API_URL}/categories`, {
         headers: { Authorization: `Bearer ${storedToken}` },
       })
-
       .then((res) => {
-        console.log([...res.data.categories]);
         const categories = [...res.data.categories];
         const categoriesArray = categories.map((category) => {
           return category.category;
         });
+
+        categoriesArray.sort();
 
         setAllCategories(categoriesArray);
       })

--- a/src/components/SelectCategories.jsx
+++ b/src/components/SelectCategories.jsx
@@ -1,36 +1,32 @@
+import API_URL from "../services/apiConfig";
+import { useState, useEffect } from "react";
+import axios from "axios";
+
+// MUI Imports
 import OutlinedInput from "@mui/material/OutlinedInput";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
 import ListItemText from "@mui/material/ListItemText";
-import Select from "@mui/material/Select";
 import Checkbox from "@mui/material/Checkbox";
-import API_URL from "../services/apiConfig";
+import Select from "@mui/material/Select";
 
-import { useState, useEffect } from "react";
-import axios from "axios";
+// --- End of imports
 
 const storedToken = localStorage.getItem("authToken");
 
 const SelectCategories = ({ categoryArray, setCategoryArray }) => {
-  const ITEM_HEIGHT = 48;
-  const ITEM_PADDING_TOP = 8;
-  const MenuProps = {
-    PaperProps: {
-      style: {
-        maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
-        width: 250,
-      },
-    },
-  };
-
   const [allCategories, setAllCategories] = useState([]);
+
+  // -------------------------------------------------------
+  // FETCH CATEGORIES FROM BACKEND
+  // -------------------------------------------------------
 
   useEffect(() => {
     axios
       .get(`${API_URL}/categories`, {
-				headers: { Authorization: `Bearer ${storedToken}` },
-			})
+        headers: { Authorization: `Bearer ${storedToken}` },
+      })
 
       .then((res) => {
         console.log([...res.data.categories]);
@@ -51,6 +47,10 @@ const SelectCategories = ({ categoryArray, setCategoryArray }) => {
     setCategoryArray(e.target.value);
   };
 
+  // -------------------------------------------------------
+  // RENDER
+  // -------------------------------------------------------
+
   return (
     <FormControl>
       <InputLabel id="select-categories">Choose</InputLabel>
@@ -63,7 +63,20 @@ const SelectCategories = ({ categoryArray, setCategoryArray }) => {
         onChange={handleSelectChange}
         input={<OutlinedInput label="Catego" />}
         renderValue={(selected) => selected.join(", ")}
-        MenuProps={MenuProps}
+        MenuProps={{
+          // Styling of dropdown window
+          PaperProps: {
+            style: {
+              maxHeight: 500,
+            },
+          },
+          // Styling of the menu items
+          MenuListProps: {
+            style: {
+              padding: "0 !important",
+            },
+          },
+        }}
       >
         {allCategories.map((cat) => (
           <MenuItem key={cat} value={cat}>

--- a/src/pages/ItemPages/CreateItemPage.jsx
+++ b/src/pages/ItemPages/CreateItemPage.jsx
@@ -11,7 +11,7 @@ function CreateItemPage() {
     <div id="main-content">
       <div id="main-section" className="justify-center p-4">
         <div className="p-4 bg-slate-50 rounded-md">
-          <SectionHeader title="Add item"></SectionHeader>
+          <SectionHeader title="Add Item"></SectionHeader>
           <div className="pb-10">
             <CreateItemSearch />
           </div>

--- a/src/pages/ItemPages/CreateItemPage.jsx
+++ b/src/pages/ItemPages/CreateItemPage.jsx
@@ -1,11 +1,12 @@
-// import CreateItemForm from "../../components/Items/CreateItemForm";
-// import { getCollectionId } from "../../services/sharedDatastore";
+import { useLocation } from "react-router-dom";
+import CreateItemForm from "../../components/Items/CreateItemForm.jsx";
 import CreateItemSearch from "../../components/Items/CreateItemSearch.jsx";
 import SectionHeader from "../../components/UI/SectionHeader";
 
 function CreateItemPage() {
-  // const collectionId = getCollectionId();
-  // console.log("CollectionID", collectionId);
+  const location = useLocation();
+  const { fromSearch } = location.state || { fromSearch: false };
+  console.log(fromSearch);
 
   return (
     <div id="main-content">
@@ -13,7 +14,7 @@ function CreateItemPage() {
         <div className="p-4 bg-slate-50 rounded-md">
           <SectionHeader title="Add Item"></SectionHeader>
           <div className="pb-10">
-            <CreateItemSearch />
+            {fromSearch ? <CreateItemForm /> : <CreateItemSearch />}
           </div>
         </div>
       </div>


### PR DESCRIPTION
OOF

- CreateItemSearch and CreateItemForm are styled and final

- Spinners were added where needed and getting it to work properly for OpenAI descriptions was a challenge, but it works now

- Items found with the search now receive the item.description and display it properly in the ItemCard

- Disabled CreateItemSearch if CreateItemPage is being requested from the SearchBar, because it made no sense to make the user search again when they weren't able to find the item in the initial search. Plus, adding exsiting items that way didn't work because the searchBar receives no collectionId.

Unfortunately, the CreateItemForm doesn't work properly through this route either (Internal Server Error, ERR_ABORTED 500). I think it's because the form when requested through searchBar isn't sending something that is required in the backend routes.

But it's two days before deadline and I'd rather not experiment in the routes too much right now, so I'm leaving it to fix on another day.

Every other way to create items works fine, though! In fact, even smoother than before and I'm very proud of it.